### PR TITLE
fix #209: correctly decode the query parameters

### DIFF
--- a/ui/assets/js/hound.js
+++ b/ui/assets/js/hound.js
@@ -60,7 +60,7 @@ var ParamsFromQueryString = function(qs, params) {
       return;
     }
 
-    params[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1]);
+    params[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1].replace(/\+/g, '%20'));
   });
 
 


### PR DESCRIPTION
The '+' character is a space in application/x-www-form-urlencoded
content, such as the query part of a URL.
