### PR TITLE
Add a search option to exclude file paths with a regexp

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -178,6 +178,7 @@ func Setup(m *http.ServeMux, idx map[string]*searcher.Searcher) {
 		query := r.FormValue("q")
 		opt.Offset, opt.Limit = parseRangeValue(r.FormValue("rng"))
 		opt.FileRegexp = r.FormValue("files")
+		opt.ExcludeFileRegexp = r.FormValue("excludeFiles")
 		opt.IgnoreCase = parseAsBool(r.FormValue("i"))
 		opt.LinesOfContext = parseAsUintValue(
 			r.FormValue("ctx"),

--- a/ui/assets/css/hound.css
+++ b/ui/assets/css/hound.css
@@ -126,7 +126,7 @@ button:focus {
 #adv > .field > label {
   /* Media object left */
   float: left;
-  width: 90px;
+  width: 100px;
   color: #999;
 }
 

--- a/ui/assets/js/hound.js
+++ b/ui/assets/js/hound.js
@@ -72,6 +72,7 @@ var ParamsFromUrl = function(params) {
     q: '',
     i: 'nope',
     files: '',
+    excludeFiles: '',
     repos: '*'
   };
   return ParamsFromQueryString(location.search, params);
@@ -370,6 +371,23 @@ var SearchBar = React.createClass({
   filesGotFocus: function(event) {
     this.showAdvanced();
   },
+  excludeFilesGotKeydown: function(event) {
+    switch (event.keyCode) {
+    case 38:
+      // if advanced is empty, close it up.
+      if (this.refs.excludeFiles.getDOMNode().value.trim() === '') {
+        this.hideAdvanced();
+      }
+      this.refs.q.getDOMNode().focus();
+      break;
+    case 13:
+      this.submitQuery();
+      break;
+    }
+  },
+  excludeFilesGotFocus: function(event) {
+    this.showAdvanced();
+  },
   submitQuery: function() {
     this.props.onSearchRequested(this.getParams());
   },
@@ -389,6 +407,7 @@ var SearchBar = React.createClass({
     return {
       q : this.refs.q.getDOMNode().value.trim(),
       files : this.refs.files.getDOMNode().value.trim(),
+      excludeFiles : this.refs.excludeFiles.getDOMNode().value.trim(),
       repos : repos.join(','),
       i: this.refs.icase.getDOMNode().checked ? 'fosho' : 'nope'
     };
@@ -396,30 +415,29 @@ var SearchBar = React.createClass({
   setParams: function(params) {
     var q = this.refs.q.getDOMNode(),
         i = this.refs.icase.getDOMNode(),
-        files = this.refs.files.getDOMNode();
+        files = this.refs.files.getDOMNode(),
+        excludeFiles = this.refs.excludeFiles.getDOMNode();
 
     q.value = params.q;
     i.checked = ParamValueToBool(params.i);
     files.value = params.files;
+    excludeFiles.value = params.excludeFiles;
   },
   hasAdvancedValues: function() {
-    return this.refs.files.getDOMNode().value.trim() !== '' || this.refs.icase.getDOMNode().checked || this.refs.repos.getDOMNode().value !== '';
+    return this.refs.files.getDOMNode().value.trim() !== '' || this.refs.excludeFiles.getDOMNode().value.trim() !== '' || this.refs.icase.getDOMNode().checked || this.refs.repos.getDOMNode().value !== '';
   },
   showAdvanced: function() {
     var adv = this.refs.adv.getDOMNode(),
         ban = this.refs.ban.getDOMNode(),
         q = this.refs.q.getDOMNode(),
-        files = this.refs.files.getDOMNode();
+        files = this.refs.files.getDOMNode(),
+        excludeFiles = this.refs.excludeFiles.getDOMNode();
 
     css(adv, 'height', 'auto');
     css(adv, 'padding', '10px 0');
 
     css(ban, 'max-height', '0');
     css(ban, 'opacity', '0');
-
-    if (q.value.trim() !== '') {
-      files.focus();
-    }
   },
   hideAdvanced: function() {
     var adv = this.refs.adv.getDOMNode(),
@@ -494,6 +512,17 @@ var SearchBar = React.createClass({
                     ref="files"
                     onKeyDown={this.filesGotKeydown}
                     onFocus={this.filesGotFocus} />
+              </div>
+            </div>
+            <div className="field">
+              <label htmlFor="excludeFiles">Exclude File Path</label>
+              <div className="field-input">
+                <input type="text"
+                    id="excludeFiles"
+                    placeholder="/regexp/"
+                    ref="excludeFiles"
+                    onKeyDown={this.excludeFilesGotKeydown}
+                    onFocus={this.excludeFilesGotFocus} />
               </div>
             </div>
             <div className="field">
@@ -760,6 +789,7 @@ var App = React.createClass({
       q: params.q,
       i: params.i,
       files: params.files,
+      excludeFiles: params.excludeFiles,
       repos: repos
     });
 
@@ -814,6 +844,7 @@ var App = React.createClass({
       '?q=' + encodeURIComponent(params.q) +
       '&i=' + encodeURIComponent(params.i) +
       '&files=' + encodeURIComponent(params.files) +
+      '&excludeFiles=' + encodeURIComponent(params.excludeFiles) +
       '&repos=' + params.repos;
     history.pushState({path:path}, '', path);
   },
@@ -824,6 +855,7 @@ var App = React.createClass({
             q={this.state.q}
             i={this.state.i}
             files={this.state.files}
+            excludeFiles={this.state.excludeFiles}
             repos={this.state.repos}
             onSearchRequested={this.onSearchRequested} />
         <ResultView ref="resultView" q={this.state.q} />


### PR DESCRIPTION
This PR adds a search field to exclude file paths with a regexp. It works exactly like the current file path search, except if it matches it rejects the file.

I made this because I have a lot of Go repositories with vendored dependencies and I'd like to be able to ignore all those files when searching.
