### PR TITLE
Add ability to use custom branch from vcs config for git

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -13,7 +13,7 @@ const (
 	defaultPushEnabled           = false
 	defaultPollEnabled           = true
 	defaultVcs                   = "git"
-	defaultBaseUrl               = "{url}/blob/master/{path}{anchor}"
+	defaultBaseUrl               = "{url}/blob/{rev}/{path}{anchor}"
 	defaultAnchor                = "#L{line}"
 )
 

--- a/vcs/git.go
+++ b/vcs/git.go
@@ -25,17 +25,15 @@ func newGit(b []byte) (Driver, error) {
 	d := &GitDriver{
 		Ref: defaultRef,
 	}
-	if e := setRefFromConfig(b, d); e != nil {
+
+	if b == nil {
+		return d, nil
+	}
+
+	if e := json.Unmarshal(b, d); e != nil {
 		return nil, e
 	}
 	return d, nil
-}
-
-func setRefFromConfig(b []byte, d *GitDriver) error {
-	if b != nil {
-		return json.Unmarshal(b, d)
-	}
-	return nil
 }
 
 func (g *GitDriver) HeadRev(dir string) (string, error) {

--- a/vcs/git.go
+++ b/vcs/git.go
@@ -2,13 +2,13 @@ package vcs
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"encoding/json"
 )
 
 const defaultRef = "master"
@@ -22,22 +22,18 @@ type GitDriver struct {
 }
 
 func newGit(b []byte) (Driver, error) {
-	d := &GitDriver{}
-	if e := getRef(b, d); e != nil {
+	d := &GitDriver{
+		Ref: defaultRef,
+	}
+	if e := setRefFromConfig(b, d); e != nil {
 		return nil, e
 	}
 	return d, nil
 }
 
-func getRef(b []byte, d *GitDriver) error {
+func setRefFromConfig(b []byte, d *GitDriver) error {
 	if b != nil {
-		if e := json.Unmarshal(b, d); e != nil {
-			return e
-		}
-	}
-	if d.Ref == "" {
-		d.Ref = defaultRef
-		return nil
+		return json.Unmarshal(b, d)
 	}
 	return nil
 }

--- a/vcs/git_test.go
+++ b/vcs/git_test.go
@@ -1,0 +1,38 @@
+package vcs
+
+import "testing"
+
+func TestGitConfigWithCustomRef(t *testing.T) {
+	cfg := `{"ref": "custom"}`
+	d, err := New("git", []byte(cfg))
+	if err != nil {
+		t.Fatal(err)
+	}
+	git := d.Driver.(*GitDriver)
+	if git.Ref != "custom" {
+		t.Fatalf("expected branch of \"custom\", got %s", git.Ref)
+	}
+}
+
+func TestGitConfigWithoutRef(t *testing.T) {
+	cfg := `{"option": "option"}`
+	d, err := New("git", []byte(cfg))
+	if err != nil {
+		t.Fatal(err)
+	}
+	git := d.Driver.(*GitDriver)
+	if git.Ref != "master" {
+		t.Fatalf("expected branch of \"master\", got %s", git.Ref)
+	}
+}
+
+func TestGitConfigWithoutAdditionalConfig(t *testing.T) {
+	d, err := New("git", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	git := d.Driver.(*GitDriver)
+	if git.Ref != "master" {
+		t.Fatalf("expected branch of \"master\", got %s", git.Ref)
+	}
+}


### PR DESCRIPTION
This PR allows us to use a custom branch for the git driver by setting a `ref` property in the `vcs-config` object.

Example:
```json
    "repos" : {
        "Hound" : {
            "url" : "https://www.github.com/etsy/Hound.git",
            "vcs-config": {
                "ref": "custom"
            }
        }
    }
```
If no `ref` or `vcs-config` properties are provided, the branch which will be targeted will be `master`.
