### PR TITLE
Add https to bitbucket base-url

### DIFF
--- a/config-example.json
+++ b/config-example.json
@@ -46,7 +46,7 @@
         "BitbucketCustomUrl" : {
             "url" : "git@bitbucket.org:organization/project.git",
             "url-pattern" : {
-                "base-url" : "{url}/src/master/{path}{anchor}",
+                "base-url" : "https://{url}/src/master/{path}{anchor}",
                 "anchor" : "#{filename}-{line}"
             }
         },


### PR DESCRIPTION
This avoids a redirect when opening bitbucket links. It should redirect browser-side after the first load since they are using HSTS, but I still see a flash for some reason. Some browsers might not support HSTS, so might as well avoid the issue entirely?