### PR TITLE
link: add vcs type for local symlink fix #134

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Hound supports the following version control systems:
 * Mercurial - use `"vcs" : "hg"` in the config
 * SVN - use `"vcs" : "svn"` in the config
 * Bazaar - use `"vcs" : "bzr"` in the config
+* Local Symlink - use `"vcs": "link"` in the config
 
 See [config-example.json](config-example.json) for examples of how to use each VCS.
 

--- a/index/index.go
+++ b/index/index.go
@@ -337,7 +337,7 @@ func containsString(haystack []string, needle string) bool {
 	return false
 }
 
-func indexAllFiles(opt *IndexOptions, dst, src string) error {
+func indexAllFiles(opt *IndexOptions, dst, path string) error {
 	ix := index.Create(filepath.Join(dst, "tri"))
 	defer ix.Close()
 
@@ -349,6 +349,12 @@ func indexAllFiles(opt *IndexOptions, dst, src string) error {
 		return err
 	}
 	defer fileHandle.Close()
+
+	src, err := filepath.EvalSymlinks(path)
+
+	if err != nil {
+		return err
+	}
 
 	if err := filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		name := info.Name()

--- a/vcs/link.go
+++ b/vcs/link.go
@@ -1,0 +1,51 @@
+package vcs
+
+import (
+	"log"
+	"os"
+	"strings"
+)
+
+func init() {
+	Register(newLinkVcs, "link")
+}
+
+type LinkVcsDriver struct{}
+
+func newLinkVcs(b []byte) (Driver, error) {
+	return &LinkVcsDriver{}, nil
+}
+
+func (g *LinkVcsDriver) HeadRev(dir string) (string, error) {
+	realdir, err := os.Readlink(dir)
+	if err != nil {
+		log.Printf("Failed to read symlink %s", dir)
+		return "", err
+	}
+
+	stat, err := os.Stat(realdir)
+	if err != nil {
+		log.Printf("Failed to determine modification time of %s", realdir)
+		return "", err
+	}
+	log.Printf("modtime %s", stat.ModTime().String())
+	return stat.ModTime().String(), nil
+}
+
+func (g *LinkVcsDriver) Pull(dir string) (string, error) {
+	return g.HeadRev(dir)
+}
+
+func (g *LinkVcsDriver) Clone(dir, url string) (string, error) {
+	err := os.Symlink(strings.Replace(url, "file://", "", 1), dir)
+	if err != nil {
+		log.Printf("Failed to link %s, see output below\nContinuing...", url)
+		return "", err
+	}
+
+	return g.HeadRev(dir)
+}
+
+func (g *LinkVcsDriver) SpecialFiles() []string {
+	return []string{}
+}


### PR DESCRIPTION
Introduces a "link" vcs type which creates a symlink and checks
frequently if ModTime of the monitored directory changed. If so, rescan.

index.go had to be modified as Walk() doesn't follow symlinks.

Signed-off-by: Paul Spooren <mail@aparcar.org>