### PR TITLE
Updated build instructions post-Etsy

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,17 @@ Go tools work accordingly. See [Setting GOPATH](https://github.com/golang/go/wik
 up your Go workspace. With a `GOPATH` set, the following commands will build hound locally.
 
 ```
-git clone https://github.com/etsy/hound.git ${GOPATH}/src/github.com/etsy/hound
+git clone https://github.com/hound-search/hound.git ${GOPATH}/src/github.com/etsy/hound
 cd ${GOPATH}/src/github.com/etsy/hound
+make
+```
+
+If this is your only Go project, you can set your GOPATH just for Hound:
+```
+git clone https://github.com/hound-search/hound.git
+cd hound
+export GOPATH=`pwd`
+go get github.com/etsy/hound/cmds/...
 make
 ```
 


### PR DESCRIPTION
The git repo path has changed now that Hound is its own org.

I also added an example build session for folks like me who
don't have other Go projects, and included the "go get" step
in these new build instructions, without which I wasn't able
to build.