### PR TITLE
fix race condition in foundRefs.claim()

### DIFF
--- a/searcher/searcher.go
+++ b/searcher/searcher.go
@@ -53,6 +53,7 @@ type limiter chan bool
 type foundRefs struct {
 	refs    []*index.IndexRef
 	claimed map[*index.IndexRef]bool
+	lock    sync.Mutex
 }
 
 func makeLimiter(n int) limiter {
@@ -85,6 +86,9 @@ func (r *foundRefs) find(url, rev string) *index.IndexRef {
  * collected at the end of startup.
  */
 func (r *foundRefs) claim(ref *index.IndexRef) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
 	r.claimed[ref] = true
 }
 
@@ -93,6 +97,9 @@ func (r *foundRefs) claim(ref *index.IndexRef) {
  * found in the dbpath but were not claimed during startup.
  */
 func (r *foundRefs) removeUnclaimed() error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
 	for _, ref := range r.refs {
 		if r.claimed[ref] {
 			continue


### PR DESCRIPTION
On re-restarting hound after the initial indexing, I got this:

```
fatal error: concurrent map writes

goroutine 49 [running]:
runtime.throw(0x14ae4f5, 0x15)
	/usr/local/Cellar/go/1.13.4/libexec/src/runtime/panic.go:774 +0x72 fp=0xc0001bbd78 sp=0xc0001bbd48 pc=0x102fb32
runtime.mapassign_fast64ptr(0x141cd80, 0xc000464060, 0xc000268e60, 0xc0004ee7e0)
	/usr/local/Cellar/go/1.13.4/libexec/src/runtime/map_fast64.go:191 +0x369 fp=0xc0001bbdb8 sp=0xc0001bbd78 pc=0x1013829
github.com/hound-search/hound/searcher.(*foundRefs).claim(...)
	/Users/igor/go/src/github.com/hound-search/hound/searcher/searcher.go:88
github.com/hound-search/hound/searcher.newSearcher(0xc000190580, 0x16, 0xc000168600, 0x22, 0xc00016a0a0, 0xc00044ee60, 0xc0004022a0, 0x657461677261662f, 0x20200a227469672e, 0x2020200a2c7d2020)
	/Users/igor/go/src/github.com/hound-search/hound/searcher/searcher.go:419 +0x356 fp=0xc0001bbee0 sp=0xc0001bbdb8 pc=0x13768d6
github.com/hound-search/hound/searcher.newSearcherConcurrent(0xc000190580, 0x16, 0xc000168600, 0x22, 0xc00016a0a0, 0xc00044ee60, 0xc0004022a0, 0xc00041aea0)
	/Users/igor/go/src/github.com/hound-search/hound/searcher/searcher.go:501 +0xe5 fp=0xc0001bbfa0 sp=0xc0001bbee0 pc=0x1376d75
runtime.goexit()
	/usr/local/Cellar/go/1.13.4/libexec/src/runtime/asm_amd64.s:1357 +0x1 fp=0xc0001bbfa8 sp=0xc0001bbfa0 pc=0x105ce31
created by github.com/hound-search/hound/searcher.MakeAll
	/Users/igor/go/src/github.com/hound-search/hound/searcher/searcher.go:296 +0x1c3
```

Adding this mutex seems to do the trick, but there might be a better higher-level fix too.