### PR TITLE
make listen URL clickable in iTerm

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ go get github.com/hound-search/hound/cmds/...
 2015/03/13 09:07:42 Searcher started for statsd
 2015/03/13 09:07:42 Searcher started for Hound
 2015/03/13 09:07:42 All indexes built!
-2015/03/13 09:07:42 running server at http://localhost:6080...
+2015/03/13 09:07:42 running server at http://localhost:6080
 ```
 
 ### Using Docker (1.4+)

--- a/cmds/houndd/main.go
+++ b/cmds/houndd/main.go
@@ -164,7 +164,7 @@ func main() {
 		}
 	}
 
-	info_log.Printf("running server at http://%s...\n", host)
+	info_log.Printf("running server at http://%s\n", host)
 
 	// Fully enable the web server now that we have indexes
 	panic(ws.ServeWithIndex(idx))


### PR DESCRIPTION
The ellipsis in the listen URL is making the listen URL non-clickable. This is just a small change, but it improves quality of life for local toying quite a bit.