### PR TITLE
Exclude file path

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -178,6 +178,7 @@ func Setup(m *http.ServeMux, idx map[string]*searcher.Searcher) {
 		query := r.FormValue("q")
 		opt.Offset, opt.Limit = parseRangeValue(r.FormValue("rng"))
 		opt.FileRegexp = r.FormValue("files")
+		opt.ExcludeFileRegexp = r.FormValue("excludeFiles")
 		opt.IgnoreCase = parseAsBool(r.FormValue("i"))
 		opt.LinesOfContext = parseAsUintValue(
 			r.FormValue("ctx"),

--- a/index/index.go
+++ b/index/index.go
@@ -41,11 +41,12 @@ type IndexOptions struct {
 }
 
 type SearchOptions struct {
-	IgnoreCase     bool
-	LinesOfContext uint
-	FileRegexp     string
-	Offset         int
-	Limit          int
+	IgnoreCase        bool
+	LinesOfContext    uint
+	FileRegexp        string
+	ExcludeFileRegexp string
+	Offset            int
+	Limit             int
 }
 
 type Match struct {
@@ -167,6 +168,14 @@ func (n *Index) Search(pat string, opt *SearchOptions) (*SearchResponse, error) 
 		}
 	}
 
+	var excludeFre *regexp.Regexp
+	if opt.ExcludeFileRegexp != "" {
+		excludeFre, err = regexp.Compile(opt.ExcludeFileRegexp)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	files := n.idx.PostingQuery(index.RegexpQuery(re.Syntax))
 	for _, file := range files {
 		var matches []*Match
@@ -175,6 +184,11 @@ func (n *Index) Search(pat string, opt *SearchOptions) (*SearchResponse, error) 
 
 		// reject files that do not match the file pattern
 		if fre != nil && fre.MatchString(name, true, true) < 0 {
+			continue
+		}
+
+		// reject files that match the exclude file pattern
+		if excludeFre != nil && excludeFre.MatchString(name, true, true) > 0 {
 			continue
 		}
 

--- a/ui/assets/css/hound.css
+++ b/ui/assets/css/hound.css
@@ -126,7 +126,7 @@ button:focus {
 #adv > .field > label {
   /* Media object left */
   float: left;
-  width: 90px;
+  width: 100px;
   color: #999;
 }
 

--- a/ui/assets/js/hound.js
+++ b/ui/assets/js/hound.js
@@ -361,7 +361,7 @@ var SearchBar = React.createClass({
     switch (event.keyCode) {
     case 38:
       // if advanced is empty, close it up.
-      if (this.refs.files.getDOMNode().value.trim() === '') {
+      if (this.isAdvancedEmpty()) {
         this.hideAdvanced();
       }
       this.refs.q.getDOMNode().focus();
@@ -378,7 +378,7 @@ var SearchBar = React.createClass({
     switch (event.keyCode) {
     case 38:
       // if advanced is empty, close it up.
-      if (this.refs.excludeFiles.getDOMNode().value.trim() === '') {
+      if (this.isAdvancedEmpty()) {
         this.hideAdvanced();
       }
       this.refs.q.getDOMNode().focus();
@@ -428,6 +428,9 @@ var SearchBar = React.createClass({
   },
   hasAdvancedValues: function() {
     return this.refs.files.getDOMNode().value.trim() !== '' || this.refs.excludeFiles.getDOMNode().value.trim() !== '' || this.refs.icase.getDOMNode().checked || this.refs.repos.getDOMNode().value !== '';
+  },
+  isAdvancedEmpty: function() {
+    return this.refs.files.getDOMNode().value.trim() === '' && this.refs.excludeFiles.getDOMNode().value.trim() === '';
   },
   showAdvanced: function() {
     var adv = this.refs.adv.getDOMNode(),

--- a/ui/assets/js/hound.js
+++ b/ui/assets/js/hound.js
@@ -76,6 +76,7 @@ var ParamsFromUrl = function(params) {
     q: '',
     i: 'nope',
     files: '',
+    excludeFiles: '',
     repos: '*'
   };
   return ParamsFromQueryString(location.search, params);
@@ -373,6 +374,23 @@ var SearchBar = React.createClass({
   filesGotFocus: function(event) {
     this.showAdvanced();
   },
+  excludeFilesGotKeydown: function(event) {
+    switch (event.keyCode) {
+    case 38:
+      // if advanced is empty, close it up.
+      if (this.refs.excludeFiles.getDOMNode().value.trim() === '') {
+        this.hideAdvanced();
+      }
+      this.refs.q.getDOMNode().focus();
+      break;
+    case 13:
+      this.submitQuery();
+      break;
+    }
+  },
+  excludeFilesGotFocus: function(event) {
+    this.showAdvanced();
+  },
   submitQuery: function() {
     this.props.onSearchRequested(this.getParams());
   },
@@ -392,6 +410,7 @@ var SearchBar = React.createClass({
     return {
       q : this.refs.q.getDOMNode().value.trim(),
       files : this.refs.files.getDOMNode().value.trim(),
+      excludeFiles : this.refs.excludeFiles.getDOMNode().value.trim(),
       repos : repos.join(','),
       i: this.refs.icase.getDOMNode().checked ? 'fosho' : 'nope'
     };
@@ -399,30 +418,29 @@ var SearchBar = React.createClass({
   setParams: function(params) {
     var q = this.refs.q.getDOMNode(),
         i = this.refs.icase.getDOMNode(),
-        files = this.refs.files.getDOMNode();
+        files = this.refs.files.getDOMNode(),
+        excludeFiles = this.refs.excludeFiles.getDOMNode();
 
     q.value = params.q;
     i.checked = ParamValueToBool(params.i);
     files.value = params.files;
+    excludeFiles.value = params.excludeFiles;
   },
   hasAdvancedValues: function() {
-    return this.refs.files.getDOMNode().value.trim() !== '' || this.refs.icase.getDOMNode().checked || this.refs.repos.getDOMNode().value !== '';
+    return this.refs.files.getDOMNode().value.trim() !== '' || this.refs.excludeFiles.getDOMNode().value.trim() !== '' || this.refs.icase.getDOMNode().checked || this.refs.repos.getDOMNode().value !== '';
   },
   showAdvanced: function() {
     var adv = this.refs.adv.getDOMNode(),
         ban = this.refs.ban.getDOMNode(),
         q = this.refs.q.getDOMNode(),
-        files = this.refs.files.getDOMNode();
+        files = this.refs.files.getDOMNode(),
+        excludeFiles = this.refs.excludeFiles.getDOMNode();
 
     css(adv, 'height', 'auto');
     css(adv, 'padding', '10px 0');
 
     css(ban, 'max-height', '0');
     css(ban, 'opacity', '0');
-
-    if (q.value.trim() !== '') {
-      files.focus();
-    }
   },
   hideAdvanced: function() {
     var adv = this.refs.adv.getDOMNode(),
@@ -497,6 +515,17 @@ var SearchBar = React.createClass({
                     ref="files"
                     onKeyDown={this.filesGotKeydown}
                     onFocus={this.filesGotFocus} />
+              </div>
+            </div>
+            <div className="field">
+              <label htmlFor="excludeFiles">Exclude File Path</label>
+              <div className="field-input">
+                <input type="text"
+                    id="excludeFiles"
+                    placeholder="regexp"
+                    ref="excludeFiles"
+                    onKeyDown={this.excludeFilesGotKeydown}
+                    onFocus={this.excludeFilesGotFocus} />
               </div>
             </div>
             <div className="field">
@@ -763,6 +792,7 @@ var App = React.createClass({
       q: params.q,
       i: params.i,
       files: params.files,
+      excludeFiles: params.excludeFiles,
       repos: repos
     });
 
@@ -817,6 +847,7 @@ var App = React.createClass({
       '?q=' + encodeURIComponent(params.q) +
       '&i=' + encodeURIComponent(params.i) +
       '&files=' + encodeURIComponent(params.files) +
+      '&excludeFiles=' + encodeURIComponent(params.excludeFiles) +
       '&repos=' + params.repos;
     history.pushState({path:path}, '', path);
   },
@@ -827,6 +858,7 @@ var App = React.createClass({
             q={this.state.q}
             i={this.state.i}
             files={this.state.files}
+            excludeFiles={this.state.excludeFiles}
             repos={this.state.repos}
             onSearchRequested={this.onSearchRequested} />
         <ResultView ref="resultView" q={this.state.q} />


### PR DESCRIPTION
This PR adds a search field to exclude file paths with a regexp. It works exactly like the current file path search, except if it matches it rejects the file.

This is the same as #223 but because I had removed my hound fork a long time ago I'm unable to update that PR.

I rebased on the latest master and did a quick test that it still works.