### PR TITLE
Update README with contact info for maintainers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,3 +160,10 @@ Created at [Etsy](https://www.etsy.com) by:
 
 * [Kelly Norton](https://github.com/kellegous)
 * [Jonathan Klein](https://github.com/jklein)
+
+Hound is maintained by:
+
+* [David Schott](https://github.com/dschott68)
+* [Jacob Rose](https://github.com/jacobrose)
+* [Nick Sawyer](https://github.com/nickmoorman)
+* [Salem Hilal](https://github.com/salemhilal)


### PR DESCRIPTION
I don't think there's a clear way to see who has push privs to this repo from the public, and even if there is, the "Get In Touch" section should probably list the maintainers.