### PR TITLE
Pin Alpine version to 3.11.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.11.6
 
 ENV GOPATH /go
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
-FROM alpine
+FROM alpine:3.10
 
 ENV GOPATH /go
 
 COPY . /go/src/github.com/hound-search/hound
-
-COPY default-config.json /data/config.json
 
 RUN apk update \
 	&& apk add go git subversion libc-dev mercurial bzr openssh \


### PR DESCRIPTION
If you run the `docker build . -t nice/hound`, you will see the following information

```bash
OK: 12750 distinct packages available
  bzr (missing):
ERROR: unsatisfiable constraints:
    required by: world[bzr]
The command '/bin/sh -c apk update 	&& apk add go git subversion libc-dev mercurial bzr openssh 	&& go install github.com/hound-search/hound/cmds/houndd 	&& apk del go 	&& rm -f /var/cache/apk/* 	&& rm -rf /go/src /go/pkg' returned a non-zero code: 1
```

This is because `bzr` has become unmaintained due to its Python2 upstream: https://gitlab.alpinelinux.org/alpine/aports/-/tree/3.12-stable/unmaintained%2Fbzr

This PR pins the Alpine's version to 3.11.6 to avoid this issue. The latest is 3.12.

A minor improvement: 
I also removed the redundant COPY because it won't be used at all. When the user runs the docker command, it always redirects the `$(pwd)` in the host system to `/data` volumn for `houndd` command.

One more question for the future:
Should we keep supporting Bazaar? I heard that it is almost dead. https://www.reddit.com/r/Ubuntu/comments/2ywrif/has_bazaar_been_deprecated/

If we keep supporting Bazaar, we should consider [breezy](https://www.breezy-vcs.org/) as a successor of `bzr`. 

