### PR TITLE
Install dependencies in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.11.6
+FROM alpine:3.11.7
 
 ENV GOPATH /go
 
@@ -6,6 +6,8 @@ COPY . /go/src/github.com/hound-search/hound
 
 RUN apk update \
 	&& apk add go git subversion libc-dev mercurial bzr openssh \
+	&& cd /go/src/github.com/hound-search/hound \
+	&& go mod download \
 	&& go install github.com/hound-search/hound/cmds/houndd \
 	&& apk del go \
 	&& rm -f /var/cache/apk/* \


### PR DESCRIPTION
This fixes the Dockerfile such that building the container image is possible using something like:

    docker build .

Without adding the `semver` package, that build command would fail with the message

```
go/src/github.com/hound-search/hound/cmds/houndd/main.go:17:2: cannot find package "github.com/blang/semver" in any of:
	/usr/lib/go/src/github.com/blang/semver (from $GOROOT)
	/go/src/github.com/blang/semver (from $GOPATH)
The command '/bin/sh -c apk update 	&& apk add go git subversion libc-dev mercurial bzr openssh 	&& go install github.com/hound-search/hound/cmds/houndd 	&& apk del go 	&& rm -f /var/cache/apk/* && rm -rf /go/src /go/pkg' returned a non-zero code: 1
```

Note that I am not super-knowledgeable about the golang ecosystem. If it is possible to build the image without such changes, please tell me, I could then add the information to the README.

In addition, the pinned alpine image was bumped to the latest bugfix release, but the build works without that specific change.
