### PR TITLE
Fix hound zombie process leak when running as container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV GOPATH /go
 COPY . /go/src/github.com/hound-search/hound
 
 RUN apk update \
-	&& apk add go git subversion libc-dev mercurial bzr openssh \
+	&& apk add go git subversion libc-dev mercurial bzr openssh tini \
 	&& cd /go/src/github.com/hound-search/hound \
 	&& go mod download \
 	&& go install github.com/hound-search/hound/cmds/houndd \
@@ -17,4 +17,4 @@ VOLUME ["/data"]
 
 EXPOSE 6080
 
-ENTRYPOINT ["/go/bin/houndd", "-conf", "/data/config.json"]
+ENTRYPOINT ["/sbin/tini", "--", "/go/bin/houndd", "-conf", "/data/config.json"]


### PR DESCRIPTION
It appears that hound leaks zombie processes when running within a Docker container as built by the project Dockerfile. Maybe because Hound does not explicitly wait for children or does not handle SIGCHLD and implicitly defers back to system init for child termination handling.

In my environment, hound polls a couple hundred git repositories. The process table starts filling up with defunct/zombie `ssh` processes immediately, until eventually (after approx. 24-48h) the process table is exhausted, preventing any further processes being spawned. When running Docker in default configuration, this actually has impact on the entire host system, as the number of processes per containers is not capped.

Workaround for Docker: Launch the hound container with the `docker run --init` option. That way, an actual init process is launched as PID 1 within the container, and `houndd` can defer child handling to it like it would in a non-containerized environment.

This pull request implements the following solution:

Modify the Dockerfile that by default `tini` is used to launch `houndd`. This is pretty much equivalent to the `docker run --init` option, but makes it explicit, and makes the Docker image work correctly out of the box.

As far as I know, adding `tini` as minimal init is standard practice when building Docker images for forking services. (In fact, `docker run --init` is actually backed by `tini`.)

Alternatives to this PR I can think of at the moment:

1. Adjust the `houndd` code such that spawned children are explicitly waited on.
2. Implement SIGCHLD handling in `houndd`.

Those solutions do not conflict with my PR, they can actually be implemented on top.

Testing done:

I tested both the new image as well as the described workaround. Both methods do not leak even a single zombie process. Reverting to the old image without `--init` workaround immediately starts leaking those processes again.