### PR TITLE
Adding a tip for windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Yup, that's it. You can proxy requests to the Go service through Apache/nginx/et
 
 ## Support
 
-Currently Hound is only tested on MacOS and CentOS, but it should work on any *nix system. Hound on Windows is not supported but we've heard it compiles and runs just fine, just remember to exclude your data folder from Windows Search Indexer and possibly the virus scanner.
+Currently Hound is only tested on MacOS and CentOS, but it should work on any *nix system. Hound on Windows is not supported but we've heard it compiles and runs just fine (although it helps to to exclude your data folder from Windows Search Indexer).
 
 Hound supports the following version control systems: 
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Yup, that's it. You can proxy requests to the Go service through Apache/nginx/et
 
 ## Support
 
-Currently Hound is only tested on MacOS and CentOS, but it should work on any *nix system. Hound on Windows is not supported but we've heard it compiles and runs just fine.
+Currently Hound is only tested on MacOS and CentOS, but it should work on any *nix system. Hound on Windows is not supported but we've heard it compiles and runs just fine, just remember to exclude your data folder from Windows Search Indexer and possibly the virus scanner.
 
 Hound supports the following version control systems: 
 


### PR DESCRIPTION
depending on where you put your hound data it could be competing with windows search indexer, which doesnt need to index this stuff. 

Also (for windows) its common for developers to have IDE and repo folders excluded form realtime virus scanning. That also competes with this indexer