### PR TITLE
replace alpine with debian based golang base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,20 @@
-FROM alpine:3.11.7
+FROM golang:1.16-buster
 
 ENV GOPATH /go
 
 COPY . /go/src/github.com/hound-search/hound
 
-RUN apk update \
-	&& apk add go git subversion libc-dev mercurial bzr openssh tini \
+RUN apt update \
+	&& apt upgrade -y \
+	&& apt install -y git subversion libc-dev mercurial bzr openssh-client tini \
 	&& cd /go/src/github.com/hound-search/hound \
 	&& go mod download \
 	&& go install github.com/hound-search/hound/cmds/houndd \
-	&& apk del go \
-	&& rm -f /var/cache/apk/* \
+	&& apt clean \
 	&& rm -rf /go/src /go/pkg
 
 VOLUME ["/data"]
 
 EXPOSE 6080
 
-ENTRYPOINT ["/sbin/tini", "--", "/go/bin/houndd", "-conf", "/data/config.json"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/go/bin/houndd", "-conf", "/data/config.json"]


### PR DESCRIPTION
attempt at fixing #375 
work in progress

I don't like that the image ends up much larger than the original alpine based one

```
etsy/hound   latest   66ef348e6d82   2 years ago     138MB
hound        temp     dfa1680178e9   9 hours ago     955MB
```