### PR TITLE
Added authenticated-url support in config

### DIFF
--- a/config-example.json
+++ b/config-example.json
@@ -1,92 +1,103 @@
 {
-    "max-concurrent-indexers" : 2,
-    "dbpath" : "data",
-    "title" : "Hound",
-    "health-check-uri" : "/healthz",
-    "vcs-config" : {
+    "max-concurrent-indexers": 2,
+    "dbpath": "data",
+    "title": "Hound",
+    "health-check-uri": "/healthz",
+    "vcs-config": {
         "git": {
-            "detect-ref" : true
+            "detect-ref": true
         }
     },
-    "repos" : {
-        "SomeGitRepo" : {
-            "url" : "https://www.github.com/YourOrganization/RepoOne.git"
+    "repos": {
+        "SomeGitRepo": {
+            "url": "https://www.github.com/YourOrganization/RepoOne.git"
         },
-        "AnotherGitRepo" : {
-            "url" : "https://www.github.com/YourOrganization/RepoOne.git",
+        "AnotherGitRepo": {
+            "url": "https://www.github.com/YourOrganization/RepoOne.git",
             "ms-between-poll": 10000,
             "exclude-dot-files": true
         },
-        "GitRepoWithDetectRefDisabled" : {
-            "url" : "https://www.github.com/YourOrganization/RepoOne.git",
-            "vcs-config" : {
-                "detect-ref" : false
+        "GitRepoWithDetectRefDisabled": {
+            "url": "https://www.github.com/YourOrganization/RepoOne.git",
+            "vcs-config": {
+                "detect-ref": false
             }
         },
-        "SomeMercurialRepo" : {
-            "url" : "https://www.example.com/foo/hg",
-            "vcs" : "hg"
+        "SomeMercurialRepo": {
+            "url": "https://www.example.com/foo/hg",
+            "vcs": "hg"
         },
-        "Subversion" : {
-            "url" : "http://my-svn.com/repo",
-            "url-pattern" : {
-                "base-url" : "{url}/{path}{anchor}"
+        "Subversion": {
+            "url": "http://my-svn.com/repo",
+            "url-pattern": {
+                "base-url": "{url}/{path}{anchor}"
             },
-            "vcs" : "svn"
+            "vcs": "svn"
         },
-        "SubversionWithCreds" : {
-            "url" : "http://my-private-svn.com/repo",
-            "url-pattern" : {
-                "base-url" : "{url}/{path}{anchor}"
+        "SubversionWithCreds": {
+            "url": "http://my-private-svn.com/repo",
+            "url-pattern": {
+                "base-url": "{url}/{path}{anchor}"
             },
-            "vcs" : "svn",
-            "vcs-config" : {
-                "username" : "username_for_ro_account",
-                "password" : "password_for_ro_account"
+            "vcs": "svn",
+            "vcs-config": {
+                "username": "username_for_ro_account",
+                "password": "password_for_ro_account"
             }
         },
-        "LocalFolder" : {
-            "url" : "file:///absolute/path/to/directory"
+        "LocalFolder": {
+            "url": "file:///absolute/path/to/directory"
         },
-        "RepoWithCustomUrls" : {
-            "url" : "https://github.com/username/Foo.git",
-            "url-pattern" : {
-                "base-url" : "{url}/files/{path}{anchor}",
-                "anchor" : "#line={line}"
+        "RepoWithCustomUrls": {
+            "url": "https://github.com/username/Foo.git",
+            "url-pattern": {
+                "base-url": "{url}/files/{path}{anchor}",
+                "anchor": "#line={line}"
             }
         },
-        "BitbucketCustomUrl" : {
-            "url" : "git@bitbucket.org:organization/project.git",
-            "url-pattern" : {
-                "base-url" : "https://{url}/src/master/{path}{anchor}",
-                "anchor" : "#{filename}-{line}"
+        "BitbucketCustomUrl": {
+            "url": "git@bitbucket.org:organization/project.git",
+            "url-pattern": {
+                "base-url": "https://{url}/src/master/{path}{anchor}",
+                "anchor": "#{filename}-{line}"
             },
-            "vcs-config" : {
-                "ref" : "main"
+            "vcs-config": {
+                "ref": "main"
             }
         },
-        "RepoWithPollingDisabled" : {
-            "url" : "https://www.github.com/YourOrganization/RepoOne.git",
-            "enable-poll-updates" : false
+        "RepoWithPollingDisabled": {
+            "url": "https://www.github.com/YourOrganization/RepoOne.git",
+            "enable-poll-updates": false
         },
-        "RepoWithPushingEnabled" : {
-            "url" : "https://www.github.com/YourOrganization/RepoOne.git",
-            "enable-push-updates" : true
+        "RepoWithPushingEnabled": {
+            "url": "https://www.github.com/YourOrganization/RepoOne.git",
+            "enable-push-updates": true
         },
-        "RepoIsGitHubWiki" : {
-          "url" : "https://github.com/YourOrganization/RepoWithWiki.wiki.git",
-          "url-pattern" : {
-              "base-url" : "{url}/{path}"
-          }
+        "RepoIsGitHubWiki": {
+            "url": "https://github.com/YourOrganization/RepoWithWiki.wiki.git",
+            "url-pattern": {
+                "base-url": "{url}/{path}"
+            }
         },
-        "BitbucketServerUrl" : {
-            "url" : "git@bitbucket.internal.org:7999:organization/project.git",
-            "url-pattern" : {
-                "base-url" : "https://{hostname}/projects/{project}/repos/{repo}/browse/{path}?at={rev}{anchor}",
-                "anchor" : "#{line}"
+        "GitLabPrivateRepoWithHttpsToken": {
+            "url": "https://gitlab.com/YourOrganization/YourRepo.git",
+            "authenticated-url": "https://AzureD-token:hunter222222@gitlab.com/YourOrganization/YourRepo.git",
+            "url-pattern": {
+                "anchor": "#L{line}",
+                "base-url": "{url}/blob/main/{path}{anchor}"
             },
-            "vcs-config" : {
-                "ref" : "main"
+            "vcs-config": {
+                "ref": "main"
+            }
+        },
+        "BitbucketServerUrl": {
+            "url": "git@bitbucket.internal.org:7999:organization/project.git",
+            "url-pattern": {
+                "base-url": "https://{hostname}/projects/{project}/repos/{repo}/browse/{path}?at={rev}{anchor}",
+                "anchor": "#{line}"
+            },
+            "vcs-config": {
+                "ref": "main"
             }
         }
     }

--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,7 @@ type UrlPattern struct {
 
 type Repo struct {
 	Url               string         `json:"url"`
+	AuthenticatedUrl  SecretString   `json:"authenticated-url"`
 	MsBetweenPolls    int            `json:"ms-between-poll"`
 	Vcs               string         `json:"vcs"`
 	VcsConfigMessage  *SecretMessage `json:"vcs-config"`
@@ -82,6 +83,13 @@ func (s *SecretMessage) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// SecretString is much like SecretMessage but it is specialized for strings
+type SecretString string
+
+// This always marshals to an empty object.
+func (s* SecretString) MarshalJSON() ([]byte, error) {
+	return []byte{ '"', '"' }, nil
+}
 // Get the JSON encode vcs-config for this repo. This returns nil if
 // the repo doesn't declare a vcs-config.
 func (r *Repo) VcsConfig() []byte {
@@ -101,6 +109,9 @@ func initRepo(r *Repo) {
 		r.Vcs = defaultVcs
 	}
 
+	if r.AuthenticatedUrl == "" {
+		r.AuthenticatedUrl = SecretString(r.Url)
+	}
 	if r.UrlPattern == nil {
 		r.UrlPattern = &UrlPattern{
 			BaseUrl: defaultBaseUrl,

--- a/searcher/searcher.go
+++ b/searcher/searcher.go
@@ -270,7 +270,7 @@ func hashFor(name string) string {
 
 // Create a normalized name for the vcs directory of this repo.
 func vcsDirFor(repo *config.Repo) string {
-	return fmt.Sprintf("vcs-%s", hashFor(string(repo.AuthenticatedUrl)))
+	return fmt.Sprintf("vcs-%s", hashFor(repo.Url))
 }
 
 func init() {

--- a/searcher/searcher.go
+++ b/searcher/searcher.go
@@ -270,7 +270,7 @@ func hashFor(name string) string {
 
 // Create a normalized name for the vcs directory of this repo.
 func vcsDirFor(repo *config.Repo) string {
-	return fmt.Sprintf("vcs-%s", hashFor(repo.Url))
+	return fmt.Sprintf("vcs-%s", hashFor(string(repo.AuthenticatedUrl)))
 }
 
 func init() {
@@ -355,10 +355,10 @@ func updateAndReindex(
 	defer lim.Release()
 
 	repo := s.Repo
-	newRev, err := wd.PullOrClone(vcsDir, repo.Url)
+	newRev, err := wd.PullOrClone(vcsDir, string(repo.AuthenticatedUrl))
 
 	if err != nil {
-		log.Printf("vcs pull error (%s - %s): %s", name, repo.Url, err)
+		log.Printf("vcs pull error (%s - %s): %s", name, string(repo.AuthenticatedUrl), err)
 		return rev, false
 	}
 
@@ -372,7 +372,7 @@ func updateAndReindex(
 		dbpath,
 		vcsDir,
 		nextIndexDir(dbpath),
-		repo.Url,
+		string(repo.AuthenticatedUrl),
 		newRev)
 	if err != nil {
 		log.Printf("failed index build (%s): %s", name, err)
@@ -412,13 +412,13 @@ func newSearcher(
 		SpecialFiles:    wd.SpecialFiles(),
 	}
 
-	rev, err := wd.PullOrClone(vcsDir, repo.Url)
+	rev, err := wd.PullOrClone(vcsDir, string(repo.AuthenticatedUrl))
 	if err != nil {
 		return nil, err
 	}
 
 	var idxDir string
-	ref := refs.find(repo.Url, rev)
+	ref := refs.find(string(repo.AuthenticatedUrl), rev)
 	if ref == nil {
 		idxDir = nextIndexDir(dbpath)
 	} else {
@@ -431,7 +431,7 @@ func newSearcher(
 		dbpath,
 		vcsDir,
 		idxDir,
-		repo.Url,
+		string(repo.AuthenticatedUrl),
 		rev)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Rationale: need to be able to use HTTPS + Access Tokens for some private GitLab repositories, but also need not to share a secret with the Hound UI users.

Implementation: a new optional key  "authenticated-url" sitting besides "url". This is not transmitted to the client.

Tests: added a config block using it but no specific test.

Tech:
Added a SecretString type just for this because SecretMessage was quirky to use with strings

More context: purpose replaces https://github.com/hound-search/hound/pull/402