### PR TITLE
Give file links a target of blank

### DIFF
--- a/ui/assets/js/hound.js
+++ b/ui/assets/js/hound.js
@@ -712,7 +712,8 @@ var FilesView = React.createClass({
             <div className="line">
               <a href={Model.UrlToRepo(repo, filename, line.Number, rev)}
                   className="lnum"
-                  target="_blank">{line.Number}</a>
+                  target="_blank"
+                  rel="noopener noreferrer">{line.Number}</a>
               <span className="lval" dangerouslySetInnerHTML={{__html:content}} />
             </div>
           );
@@ -726,7 +727,9 @@ var FilesView = React.createClass({
       return (
         <div className="file">
           <div className="title">
-            <a href={Model.UrlToRepo(repo, match.Filename, null, rev)}>
+            <a href={Model.UrlToRepo(repo, match.Filename, null, rev)}
+                target="_blank"
+                rel="noopener noreferrer">
               {match.Filename}
             </a>
           </div>


### PR DESCRIPTION
Individual links to line numbers open in a new target. Links to the file (at the top of the list of line number links) open in the same window / tab. This PR makes them behave consistently with line links.

Add rel="noopener noreferrer" to _blank links