### PR TITLE
Remove default branch warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,6 @@
 [![Build Status](https://travis-ci.org/hound-search/hound.svg?branch=master)](https://travis-ci.org/hound-search/hound)
 [![.github/workflows/go.yaml](https://github.com/hound-search/hound/workflows/.github/workflows/go.yaml/badge.svg)](https://github.com/hound-search/hound/actions)
 
-> ## :warning: Hound's default branch name has changed! :warning:
-> **We renamed our default branch from `master` to `main` on February 24, 2021**. We used [GitHub's branch renaming feature](https://github.com/github/renaming/#renaming-existing-branches), which means that any open pull requests should be automatically re-targeted, and web requests pointing to code on the `master` branch should redirect as expected. This change should mostly be invisible, but you will need to update any code that explicitly relies on the existence of Hound's `master` branch.
-
 Hound is an extremely fast source code search engine. The core is based on this article (and code) from Russ Cox:
 [Regular Expression Matching with a Trigram Index](http://swtch.com/~rsc/regexp/regexp4.html). Hound itself is a static
 [React](http://facebook.github.io/react/) frontend that talks to a [Go](http://golang.org/) backend. The backend keeps an up-to-date index for each repository and answers searches through a minimal API. Here it is in action:


### PR DESCRIPTION
It's been almost a year since we renamed the default branch to `main`. The warning can probably be taken out.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Docs update

**The PR fulfills these requirements:**
- [x] All tests are passing?
- [x] New/updated tests are included?
- [x] If any static assets have been updated, has ui/bindata.go been regenerated?
- [x] Are there doc blocks for functions that I updated/created?
