### PR TITLE
Adding the setup-qemu-action to enable multiplatform docker builds from github actions

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -37,6 +37,8 @@ jobs:
             TAGS="$TAGS,${DOCKER_IMAGE}:latest"
           fi
           echo ::set-output name=tags::${TAGS}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to GitHub Packages Docker Registry
@@ -49,6 +51,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: ./Dockerfile
           push: true
           tags: ${{ steps.prep.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@ ENV GOPATH /go
 COPY . /go/src/github.com/hound-search/hound
 
 RUN apk update \
-	&& apk add go git subversion libc-dev mercurial bzr openssh tini \
+	&& apk add go git subversion libc-dev mercurial bzr openssh tini build-base\
 	&& cd /go/src/github.com/hound-search/hound \
 	&& go mod download \
 	&& go install github.com/hound-search/hound/cmds/houndd \
-	&& apk del go \
+	&& apk del go build-base \
 	&& rm -f /var/cache/apk/* \
 	&& rm -rf /go/src /go/pkg
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:
-- CI change to enable multi platform docker builds

**The PR fulfills these requirements:**
- [x] All tests are passing?
- [ ] New/updated tests are included?
- [ ] If any static assets have been updated, has ui/bindata.go been regenerated?
- [ ] Are there doc blocks for functions that I updated/created?

**Other information:**
When following the `Using Docker` section of README on arm laptop I get a docker warning about the image platform mismatch.

My goal with this change is to have GH Actions build both amd64 and arm64 platformed images