### PR TITLE
Add config.json to .gitignore and add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+/.vagrant
+/node_modules
+.DS_Store
+*.exe
+/db
+/data
+/.idea
+dist/
+config.json

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /data
 /.idea
 dist/
+config.json


### PR DESCRIPTION
This is a very small change. If you follow the README, you will end up creating a `config.json` in the root of the repo. This will prevent that from causing a non-clean git status.

It is also helpful for development so that you can have a config file in the repo for testing.

This PR also adds a .dockerignore file which mirrors .gitignore with a few exceptions. Without it, building locally sucks if you have large test db test data in your repo as Docker copies all of that into the context to build even though it's not needed.