### PR TITLE
Add user to container to support running as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,11 @@ RUN apk update \
 	&& rm -f /var/cache/apk/* \
 	&& rm -rf /go/src /go/pkg
 
+# Hardcode gid and uid so that it never changes. This changing will break
+# users running this as nonroot in production as you run it with the uid directly,
+# not the user name.
+RUN addgroup -g 1000 hound && adduser -u 1000 -G hound -D hound
+
 VOLUME ["/data"]
 
 EXPOSE 6080

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ You should be able to navigate to [http://localhost:6080/](http://localhost:6080
 There are no special flags to run Hound in production. You can use the `--addr=:6880` flag to control the port to which the server binds. 
 Currently, Hound does not support TLS as most users simply run Hound behind either Apache or nginx. However, we are open to contributions to add TLS support.
 
+If you are running the container, it is best security practice to run containers as non-root users in production. There is a hound user and group in the container with the uid/guid of 1000/1000. For example, utilizing this user with docker would look like:
+
+```
+docker run -d -u 1000 -p 6080:6080 --name hound -v $(pwd):/data ghcr.io/hound-search/hound:latest
+```
+
 ## Why Another Code Search Tool?
 
 We've used many similar tools in the past, and most of them are either too slow, too hard to configure, or require too much software to be installed.


### PR DESCRIPTION
Running docker containers as root in production is not good security practice for a lot of reasons. It is difficult to use the images provide without running as root there is no user to run it as. This PR adds a user so that one can run hound as non-root. 

I did not change the default user of the container so this should have no effect on those already utilizing the container and expecting it to run as root.

This will allow one to easily run the container as non-root with Docker, Kuberntes, etc (See README change).

<!--
Please make sure to read the Contributing Guidelines:
https://github.com/hound-search/hound/blob/main/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**The PR fulfills these requirements:**
- [x ] All tests are passing?
- [ ] New/updated tests are included?
- [ ] If any static assets have been updated, has ui/bindata.go been regenerated?
- [ ] Are there doc blocks for functions that I updated/created?

If adding a **new feature**, the PR's description includes:
- [x ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
