### PR TITLE
Update Makefile to reflect the move to a go module.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CMDS := $(GOPATH)/bin/houndd $(GOPATH)/bin/hound
+CMDS := .build/bin/houndd .build/bin/hound
 
 SRCS := $(shell find . -type f -name '*.go')
 
@@ -11,25 +11,27 @@ ALL: $(CMDS)
 
 ui: ui/bindata.go
 
-node_modules:
+# the mtime is updated on a directory when its files change so it's better
+# to rely on a single file to represent the presence of node_modules.
+node_modules/build:
 	npm install
+	date -u >> $@
 
-$(GOPATH)/bin/houndd: ui/bindata.go $(SRCS)
-	go install github.com/hound-search/hound/cmds/houndd
+.build/bin/houndd: ui/bindata.go $(SRCS)
+	go build -o $@ github.com/hound-search/hound/cmds/houndd
 
-$(GOPATH)/bin/hound: ui/bindata.go $(SRCS)
-	go install github.com/hound-search/hound/cmds/hound
+.build/bin/hound: ui/bindata.go $(SRCS)
+	go build -o $@ github.com/hound-search/hound/cmds/hound
 
 .build/bin/go-bindata:
-	GOPATH=`pwd`/.build go get github.com/go-bindata/go-bindata/...
+	go build -o $@ github.com/go-bindata/go-bindata/go-bindata
 
-ui/bindata.go: .build/bin/go-bindata node_modules $(wildcard ui/assets/**/*)
+ui/bindata.go: .build/bin/go-bindata node_modules/build $(wildcard ui/assets/**/*)
 	rsync -r ui/assets/* .build/ui
 	npx webpack $(WEBPACK_ARGS)
 	$< -o $@ -pkg ui -prefix .build/ui -nomemcopy .build/ui/...
 
-dev: ALL
-	npm install
+dev: node_modules/build
 
 test:
 	go test github.com/hound-search/hound/...

--- a/README.md
+++ b/README.md
@@ -125,21 +125,15 @@ Currently the following editors have plugins that support Hound:
  * make
  * Node.js ([Installation Instructions](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager))
 
-Hound includes a `Makefile` to aid in building locally, but it depends on the source being added to a proper Go workspace so that
-Go tools work accordingly. See [Setting GOPATH](https://github.com/golang/go/wiki/SettingGOPATH) for further details about setting
-up your Go workspace. With a `GOPATH` set, the following commands will build hound locally.
+While Hound is a proper go module that can be installed with `go install`, there is also a `Makefile` to aid in building locally.
 
 ```
-git clone https://github.com/hound-search/hound.git ${GOPATH}/src/github.com/hound-search/hound
-cd ${GOPATH}/src/github.com/hound-search/hound
+git clone https://github.com/hound-search/hound.git
+cd hound
 make
 ```
 
-If this is your only Go project, you can set your GOPATH just for Hound:
-```
-git clone https://github.com/hound-search/hound.git src/github.com/hound-search/hound
-GOPATH=$(pwd) make -C src/github.com/hound-search/hound
-```
+The hound executables will be available in `.build/bin`.
 
 ### Testing
 
@@ -182,7 +176,7 @@ make dev
 Then run the hound server with the --dev option:
 
 ```
-bin/houndd --dev
+.build/bin/houndd --dev
 ```
 
 ## Get in Touch

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,0 +1,6 @@
+package tools
+
+import (
+	// used for bundling ui assets
+	_ "github.com/go-bindata/go-bindata"
+)


### PR DESCRIPTION
## What kind of change does this PR introduce? (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

## The PR fulfills these requirements:
- [x] All tests are passing?
- [ ] New/updated tests are included?
- [ ] If any static assets have been updated, has ui/bindata.go been regenerated?
- [ ] Are there doc blocks for functions that I updated/created?

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

## Other information:
Since Hound is now a proper Go module, we can avoid a lot of the complexity of setting up the `GOPATH` that we used to have to deal with. This updates the `Makefile` so that `GOPATH` hijinks is no longer required to build locally. The one caveat is that `houndd` and `hound` will be built into `.build/bin` instead of `$GOPATH/bin`. 

A few other changes explained:

### Why tools/tools.go?
A go module should explicitly reference its dependencies somewhere. `go mod tidy` is often used to cull dependencies that are no longer needed in a go module. This poses a problem for dependencies that are build related as they are only referenced in the build system. A convention that is often used, and which I'm using here, is to add an explicit code reference to those dependencies in a package that is not actually reachable from the `main` module ... but tells tools like `go mod tidy` that the dependency is used.

### Why update the node_modules rule to node_modules/build?
Since I created this `Makefile`, I found that make targets that reference a directory are unreliable. Make often believes they have been invalidated when they haven't. It seems to be best practice to not have a directory as a target in gnu make because of differences in the way mtime is updated for directories. So I've started making all my `node_modules` make targets point to a file within the `node_modules` directory.