### PR TITLE
chore: add manual install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ print out the installed version of go.
 
   You might have to change the path of the last command if you installed Go somewhere else on your system.
 
-2. Create a config.json file and use it to list your repositories. Check out our [example-config.json](config-example.json) 
+2. Create a config.json file in your `$GOPATH/bin` and use it to list your repositories. Check out our [example-config.json](config-example.json)
 to see how to set up various types of repositories. For example, we can configure Hound to search its own source code using 
 the config found in [default-config.json](default-config.json):
 
@@ -52,8 +52,9 @@ the config found in [default-config.json](default-config.json):
 ```
 
 
-A complete list of available config options can be found [here](docs/config-options.md).  
-3. Run the Hound server with `houndd` in the same directory as your `config.json`. You should see output similar to:
+A complete list of available config options can be found [here](docs/config-options.md).
+
+3. Run the Hound server with `houndd` in the same directory as your `config.json`, which is most likely your `$GOPATH/bin` directory. You should see output similar to:
 ```
 2015/03/13 09:07:42 Searcher started for statsd
 2015/03/13 09:07:42 Searcher started for Hound

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ print out the installed version of go.
 
 1. Use the Go tools to install Hound. The binaries `houndd` (server) and `hound` (cli) will be installed in your $GOPATH/bin directory. Your $GOPATH should be in your $PATH (`echo $PATH` to check).
 
-
   ```
   go get github.com/hound-search/hound/cmds/...
   ```
@@ -42,25 +41,24 @@ print out the installed version of go.
 to see how to set up various types of repositories. For example, we can configure Hound to search its own source code using 
 the config found in [default-config.json](default-config.json):
 
-```json
-{
-  "dbpath" : "db",
-  "repos" : {
-    "Hound" : { "url" : "https://github.com/etsy/hound.git" }
+  ```json
+  {
+    "dbpath" : "db",
+    "repos" : {
+      "Hound" : { "url" : "https://github.com/etsy/hound.git" }
+    }
   }
-}
-```
+  ```
 
-
-A complete list of available config options can be found [here](docs/config-options.md).
+  A complete list of available config options can be found [here](docs/config-options.md).
 
 3. Run the Hound server with `houndd` in the same directory as your `config.json`, which is most likely your `$GOPATH/bin` directory. You should see output similar to:
-```
-2015/03/13 09:07:42 Searcher started for statsd
-2015/03/13 09:07:42 Searcher started for Hound
-2015/03/13 09:07:42 All indexes built!
-2015/03/13 09:07:42 running server at http://localhost:6080
-```
+  ```
+  2015/03/13 09:07:42 Searcher started for statsd
+  2015/03/13 09:07:42 Searcher started for Hound
+  2015/03/13 09:07:42 All indexes built!
+  2015/03/13 09:07:42 running server at http://localhost:6080
+  ```
 
 4. By default, hound hosts a web ui at http://localhost:6080 . Open it in your browser, and start searching.
 

--- a/README.md
+++ b/README.md
@@ -22,21 +22,21 @@ print out the installed version of go.
 1. Use the Go tools to install Hound. The binaries `houndd` (server) and `hound` (cli) will be installed in your $GOPATH/bin directory. Your $GOPATH should be in your $PATH (`echo $PATH` to check).
 
 
-```
-go get github.com/hound-search/hound/cmds/...
-```
+  ```
+  go get github.com/hound-search/hound/cmds/...
+  ```
 
-If the above doesn't work for you, try to install hound manually with the following:
+  If the above doesn't work for you, try to install hound manually with the following:
 
-```
-git clone https://github.com/hound-search/hound.git
-cd hound
-go build ./cmds/hound
-go build ./cmds/houndd
-sudo mv hound houndd ~/go/bin/
-```
+  ```
+  git clone https://github.com/hound-search/hound.git
+  cd hound
+  go build ./cmds/hound
+  go build ./cmds/houndd
+  sudo mv hound houndd ~/go/bin/
+  ```
 
-You might have to change the path of the last command if you installed Go somewhere else on your system.
+  You might have to change the path of the last command if you installed Go somewhere else on your system.
 
 2. Create a config.json file and use it to list your repositories. Check out our [example-config.json](config-example.json) 
 to see how to set up various types of repositories. For example, we can configure Hound to search its own source code using 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ print out the installed version of go.
 go get github.com/hound-search/hound/cmds/...
 ```
 
+If the above doesn't work for you, try to install hound manually with the following:
+
+```
+git clone https://github.com/hound-search/hound.git
+cd hound
+go build ./cmds/hound
+go build ./cmds/houndd
+sudo mv hound houndd ~/go/bin/
+```
+
+You might have to change the path of the last command if you installed Go somewhere else on your system.
+
 2. Create a config.json file and use it to list your repositories. Check out our [example-config.json](config-example.json) 
 to see how to set up various types of repositories. For example, we can configure Hound to search its own source code using 
 the config found in [default-config.json](default-config.json):


### PR DESCRIPTION
With the help from [this issue](https://github.com/hound-search/hound/issues/423), this PR add a manual installation option as well as specifying directory for `config.json` in README


**What kind of change does this PR introduce?** (check at least one)

- [x] Other, please describe: README

**The PR fulfills these requirements:**
- [x] ~~All tests are passing?~~
- [x] ~~New/updated tests are included?~~
- [x] ~~If any static assets have been updated, has ui/bindata.go been regenerated?~~
- [x] ~~Are there doc blocks for functions that I updated/created?~~
All the above don't apply to this PR

