### PR TITLE
Add `display-name` option to customize/disambiguate output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,8 @@ your changes (you can read more about pull requests on GitHub [here](http://help
 
 When you send a pull request, please be sure to include: 
 - unit tests that validate that your changes work as expected (both for Go and for JavaScript changes)
-- consice code comments (it can help to imagine that you're explaining your code to a total stranger)
-- an examples, if necessary.
+- concise code comments (it can help to imagine that you're explaining your code to a total stranger)
+- one or more examples, if necessary.
 
 ## More
 Hound is a volunteer effort. We do our best to try and review contributions in a timely manner. Any code or feedback 

--- a/client/client.go
+++ b/client/client.go
@@ -61,6 +61,10 @@ func repoNameFor(repos map[string]*config.Repo, repo string) string {
 		return repo
 	}
 
+	if data.DisplayName != "" {
+		return data.DisplayName
+	}
+
 	name := repoNameFromUrl(data.Url)
 	if name == "" {
 		return repo

--- a/config-example.json
+++ b/config-example.json
@@ -16,7 +16,7 @@
             "url" : "https://www.github.com/YourOrganization/RepoOne.git",
             "ms-between-poll": 10000,
             "exclude-dot-files": true,
-            "display-name": "YourOrganization/RepoOne [no dotfiles]",
+            "display-name": "RepoOne (dot files not indexed)",
             "auto-generated-files": ["example/path"]
         },
         "GitRepoWithDetectRefDisabled" : {

--- a/config-example.json
+++ b/config-example.json
@@ -16,6 +16,7 @@
             "url" : "https://www.github.com/YourOrganization/RepoOne.git",
             "ms-between-poll": 10000,
             "exclude-dot-files": true,
+            "display-name": "YourOrganization/RepoOne [no dotfiles]",
             "auto-generated-files": ["example/path"]
         },
         "GitRepoWithDetectRefDisabled" : {

--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,7 @@ type UrlPattern struct {
 
 type Repo struct {
 	Url                string         `json:"url"`
+	DisplayName        string         `json:"display-name"`
 	MsBetweenPolls     int            `json:"ms-between-poll"`
 	Vcs                string         `json:"vcs"`
 	VcsConfigMessage   *SecretMessage `json:"vcs-config"`

--- a/docs/config-options.md
+++ b/docs/config-options.md
@@ -45,6 +45,7 @@ Options for url used for repo link under repos
 
 URLOptions | Description | Default Values
 :------ | :--- | :-----
+display-name | alternative display name for repo | ""
 url-pattern | when provided used by Hound for config|`{url}/blob/{rev}/{path}{anchor}`
 anchor | when provided used for vcs config| `#L{line}`
 

--- a/ui/assets/js/hound.js
+++ b/ui/assets/js/hound.js
@@ -255,6 +255,10 @@ var Model = {
             return repo;
         }
 
+        if (info['display-name']) {
+          return info['display-name'];
+        }
+
         var url = info.url,
             ax = url.lastIndexOf("/");
         if (ax < 0) {


### PR DESCRIPTION
<!--
Please make sure to read the Contributing Guidelines:
https://github.com/hound-search/hound/blob/main/CONTRIBUTING.md
-->

This PR introduces an optional `display-name` field in the repo configuration, which allows the user to override the default `parent/repo` format.  This is useful, for example, when indexing the same repo with different config options (e.g. main branch and feature branch).

E.g. this config file:
```
{
  "dbpath" : "db",
  "vcs-config" : {
    "git": {
      "ref" : "main"
    }
  },
  "repos" : {
    "Hound" : {
      "url" : "https://github.com/awf/hound.git"
    },
    "Hound/alpine" : {
      "url" : "https://github.com/hound-search/hound.git",
      "display-name" : "Hound (alpine)",
      "vcs-config" : {
        "git": {
          "ref" : "alpine"
        }
      }
    }
  }
}
```
produces this output (the red text) from the CLI client
![image](https://user-images.githubusercontent.com/128119/231775996-c4b727e3-4cf5-4792-970d-baddf4861a27.png)

and this on HTML
![image](https://user-images.githubusercontent.com/128119/231776244-7f19ea93-bdeb-4e74-8571-34d90989256c.png)



<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**The PR fulfills these requirements:**
- [x] All tests are passing?
- [x] New/updated tests are included?
- [x] If any static assets have been updated, has ui/bindata.go been regenerated?
- [x] Are there doc blocks for functions that I updated/created?

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
