### PR TITLE
Add support for manually setting a limit on results(copy)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -18,6 +18,7 @@ import (
 const (
 	defaultLinesOfContext uint = 2
 	maxLinesOfContext     uint = 20
+	maxLimit              int  = 100000
 )
 
 type Stats struct {
@@ -128,9 +129,23 @@ func parseAsUintValue(sv string, min, max, def uint) uint {
 		return max
 	}
 	if min != 0 && uint(iv) < min {
-		return max
+		return min
 	}
 	return uint(iv)
+}
+
+func parseAsIntValue(sv string, min, max, def int) int {
+	iv, err := strconv.ParseInt(sv, 10, 64)
+	if err != nil {
+		return def
+	}
+	if max != 0 && int(iv) > max {
+		return max
+	}
+	if min != 0 && int(iv) < min {
+		return min
+	}
+	return int(iv)
 }
 
 func parseRangeInt(v string, i *int) {
@@ -159,8 +174,7 @@ func parseRangeValue(rv string) (int, int) {
 	return b, e
 }
 
-func Setup(m *http.ServeMux, idx map[string]*searcher.Searcher) {
-
+func Setup(m *http.ServeMux, idx map[string]*searcher.Searcher, defaultMaxResults int) {
 	m.HandleFunc("/api/v1/repos", func(w http.ResponseWriter, r *http.Request) {
 		res := map[string]*config.Repo{}
 		for name, srch := range idx {
@@ -181,6 +195,11 @@ func Setup(m *http.ServeMux, idx map[string]*searcher.Searcher) {
 		opt.ExcludeFileRegexp = r.FormValue("excludeFiles")
 		opt.IgnoreCase = parseAsBool(r.FormValue("i"))
 		opt.LiteralSearch = parseAsBool(r.FormValue("literal"))
+		opt.MaxResults = parseAsIntValue(
+			r.FormValue("limit"),
+			-1,
+			maxLimit,
+			defaultMaxResults)
 		opt.LinesOfContext = parseAsUintValue(
 			r.FormValue("ctx"),
 			0,

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"testing"
+)
+
+var parseAsIntAndUintTests = map[string]struct {
+	numResults string
+	min int
+	max	int
+	def	int
+	expected int
+} {
+	"parse error test case": {"not a parsable integer", 101, 1000, 5000, 5000},
+	"less than min test case": {"100", 101, 1000, 5000, 101},
+	"greater than max test case": {"1001", 101, 1000, 5000, 1000},
+	"within limits test case": {"100", 0, 100, 5000, 100},
+}
+
+func TestParseAsIntAndUint(t *testing.T) {
+	for name, td := range parseAsIntAndUintTests {
+		t.Run(name, func(t *testing.T) {
+			if got, expected := 
+				parseAsUintValue(td.numResults, uint(td.min), uint(td.max), uint(td.def)), uint(td.expected); got != expected {
+					t.Fatalf("parseAsUintValue - %s: returned %d; expected %d", name, got, expected)
+				}
+
+			if got, expected := 
+				parseAsIntValue(td.numResults, td.min, td.max, td.def), td.expected; got != expected {
+					t.Fatalf("parseAsIntValue - %s: returned %d; expected %d", name, got, expected)
+				}
+		})	
+	}
+}

--- a/cmds/houndd/main.go
+++ b/cmds/houndd/main.go
@@ -111,7 +111,7 @@ func runHttp( //nolint
 	}
 
 	m.Handle("/", h)
-	api.Setup(m, idx)
+	api.Setup(m, idx, cfg.ResultLimit)
 	return http.ListenAndServe(addr, m)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ const (
 	defaultBaseUrl               = "{url}/blob/{rev}/{path}{anchor}"
 	defaultAnchor                = "#L{line}"
 	defaultHealthCheckURI        = "/healthz"
+	defaultResultLimit           = 5000
 )
 
 type UrlPattern struct {
@@ -63,6 +64,7 @@ type Config struct {
 	MaxConcurrentIndexers int                       `json:"max-concurrent-indexers"`
 	HealthCheckURI        string                    `json:"health-check-uri"`
 	VCSConfigMessages     map[string]*SecretMessage `json:"vcs-config"`
+	ResultLimit           int                       `json:"result-limit"`
 }
 
 // SecretMessage is just like json.RawMessage but it will not
@@ -128,6 +130,10 @@ func initConfig(c *Config) error {
 
 	if c.HealthCheckURI == "" {
 		c.HealthCheckURI = defaultHealthCheckURI
+	}
+
+	if c.ResultLimit == 0 {
+		c.ResultLimit = defaultResultLimit
 	}
 
 	return mergeVCSConfigs(c)

--- a/index/dummy_en.txt
+++ b/index/dummy_en.txt
@@ -1,0 +1,1122 @@
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text
+some text
+some text
+a line that has a code 8365a and then some more text
+some text
+some text
+some text

--- a/index/dummy_es.txt
+++ b/index/dummy_es.txt
@@ -1,0 +1,325 @@
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras
+varias palabras
+varias palabras
+una linea de texto que tiene el codigo 8365a y unas palabras mas
+varias palabras
+varias palabras

--- a/web/web.go
+++ b/web/web.go
@@ -77,7 +77,7 @@ func (s *Server) ServeWithIndex(idx map[string]*searcher.Searcher) error {
 
 	m := http.NewServeMux()
 	m.Handle("/", h)
-	api.Setup(m, idx)
+	api.Setup(m, idx, s.cfg.ResultLimit)
 
 	s.serveWith(m)
 


### PR DESCRIPTION
These changes were copied from https://github.com/hound-search/hound/pull/408 which was closed cause I accidentally pushed the main branch on the contributor's fork(I meant to push a copy of his branch with my changes instead of main).

I didn't make any other changes besides adding some [tests](https://github.com/hound-search/hound/commit/1103c328d5fef9e0776b940cfc28d39fa12b622e) for `parseAsIntValue` and `parseAsUintValue`.