### PR TITLE
Prevent line numbers from being copied in search results

### DIFF
--- a/ui/assets/css/hound.css
+++ b/ui/assets/css/hound.css
@@ -321,6 +321,10 @@ button:focus {
   display: inline-block;
   font-size: 14px;
   color: #767676;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .match > .line:last-child > .lnum {


### PR DESCRIPTION
<!--
Please make sure to read the Contributing Guidelines:
https://github.com/hound-search/hound/blob/main/CONTRIBUTING.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**The PR fulfills these requirements:**
- [x] All tests are passing?
- [ ] New/updated tests are included?
- [x] If any static assets have been updated, has ui/bindata.go been regenerated?
- [ ] Are there doc blocks for functions that I updated/created?

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
When I want to copy multiple lines of code from the search results, the line numbers are also copied.
![image](https://github.com/hound-search/hound/assets/43534663/5f091aa4-37b8-4d9d-8f09-8cf4a4da0397)

So when I paste this into IDE or console, it may cause syntax errors.
![image](https://github.com/hound-search/hound/assets/43534663/3c7c30e8-9de8-4c7a-b062-9ca65632818f)

The solution is to prevent line numbers from being copied in search results using CSS.
![image](https://github.com/hound-search/hound/assets/43534663/8983f9ba-ee99-4c5d-a3bc-045ba45000f1)

I hope this little trick is helpful.

P.S. As I noticed, now there is no need to regenerate`ui/bindata.go`. So this line may be deleted from PR template. Right?
